### PR TITLE
D8 nid 87

### DIFF
--- a/nicsdru_nidirect_theme.theme
+++ b/nicsdru_nidirect_theme.theme
@@ -5,42 +5,24 @@
  * Functions to support theming in the nicsdru_nidirect_theme theme.
  */
 
-
 /**
  * Implements hook_preprocess_field().
  */
-function nicsdru_nidirect_theme_preprocess_field(&$variables)
-{
+function nicsdru_nidirect_theme_preprocess_field(&$variables) {
   // Implement audit link.
   if (isset($variables['element'])
     && isset($variables['element']['#entity_type'])
     && ($variables['element']['#entity_type'] == 'node')
   ) {
-    // Only start this processing if the 'nidirect_workflow' module is installed.
+    // Only start this processing if the 'nidirect_workflow'
+    // module is installed.
     if (\Drupal::service('module_handler')->moduleExists('nidirect_workflow')) {
       $content_type = $variables['element']['#bundle'];
       switch ($content_type) {
         case 'health_condition':
-          // ** check to see if this node is due for audit
-          // Get the current node.
-          $node = \Drupal::routeMatch()->getParameter('node');
-          if (!empty($node) && is_object($node)) {
-            $nid = $node->id();
-            if (!empty($nid)) {
-              // See if audit is due.
-              $next_audit_date = $node->get('field_next_audit_due')->value;
-              if (strtotime($next_audit_date) < strtotime("now")) {
-                // Next audit date is in the past, so this node is due for audit.
-                $variables['audit_link'] = '<a href="/nidirect_workflow/content_audit/' . $nid . '?destination=node/' . $nid . '" title="Click this link to indicate you have checked this content for accuracy and relevance" class="flag unflag-action flag-link-confirm" rel="nofollow">Audit this published content</a>';
-              }
-            }
-          }
-          break;
-
         case 'article':
         case 'contact':
         case 'page':
-          // ** check to see if this node is due for audit
           // Get the current node.
           $node = \Drupal::routeMatch()->getParameter('node');
           if (!empty($node) && is_object($node)) {
@@ -49,7 +31,8 @@ function nicsdru_nidirect_theme_preprocess_field(&$variables)
               // See if audit is due.
               $next_audit_date = $node->get('field_next_audit_due')->value;
               if (strtotime($next_audit_date) < strtotime("now")) {
-                // Next audit date is in the past, so this node is due for audit.
+                // Next audit date is in the past,
+                // so this node is due for audit - display the audit link.
                 $variables['audit_link'] = '<a href="/nidirect_workflow/content_audit/' . $nid . '?destination=node/' . $nid . '" title="Click this link to indicate you have checked this content for accuracy and relevance" class="flag unflag-action flag-link-confirm" rel="nofollow">Audit this published content</a>';
               }
             }

--- a/nicsdru_nidirect_theme.theme
+++ b/nicsdru_nidirect_theme.theme
@@ -46,7 +46,12 @@ function nicsdru_nidirect_theme_preprocess_field(&$variables)
           if (!empty($node) && is_object($node)) {
             $nid = $node->id();
             if (!empty($nid)) {
-              $variables['audit_link'] = '<a href="/nidirect_workflow/content_audit/' . $nid . '?destination=node/' . $nid . '" title="Click this link to indicate you have checked this content for accuracy and relevance" class="flag unflag-action flag-link-confirm" rel="nofollow">Audit this published content</a>';
+              // See if audit is due.
+              $next_audit_date = $node->get('field_next_audit_due')->value;
+              if (strtotime($next_audit_date) < strtotime("now")) {
+                // Next audit date is in the past, so this node is due for audit.
+                $variables['audit_link'] = '<a href="/nidirect_workflow/content_audit/' . $nid . '?destination=node/' . $nid . '" title="Click this link to indicate you have checked this content for accuracy and relevance" class="flag unflag-action flag-link-confirm" rel="nofollow">Audit this published content</a>';
+              }
             }
           }
           break;

--- a/nicsdru_nidirect_theme.theme
+++ b/nicsdru_nidirect_theme.theme
@@ -22,13 +22,17 @@ function nicsdru_nidirect_theme_preprocess_field(&$variables)
       switch ($content_type) {
         case 'health_condition':
           // ** check to see if this node is due for audit
-          // ** check to see if workflow module installed
           // Get the current node.
           $node = \Drupal::routeMatch()->getParameter('node');
           if (!empty($node) && is_object($node)) {
             $nid = $node->id();
             if (!empty($nid)) {
-              $variables['audit_link'] = '<a href="/nidirect_workflow/content_audit/' . $nid . '?destination=node/' . $nid . '" title="Click this link to indicate you have checked this content for accuracy and relevance" class="flag unflag-action flag-link-confirm" rel="nofollow">Audit this published content</a>';
+              // See if audit is due.
+              $next_audit_date = $node->get('field_next_audit_due')->value;
+              if (strtotime($next_audit_date) < strtotime("now")) {
+                // Next audit date is in the past, so this node is due for audit.
+                $variables['audit_link'] = '<a href="/nidirect_workflow/content_audit/' . $nid . '?destination=node/' . $nid . '" title="Click this link to indicate you have checked this content for accuracy and relevance" class="flag unflag-action flag-link-confirm" rel="nofollow">Audit this published content</a>';
+              }
             }
           }
           break;
@@ -37,7 +41,6 @@ function nicsdru_nidirect_theme_preprocess_field(&$variables)
         case 'contact':
         case 'page':
           // ** check to see if this node is due for audit
-          // ** check to see if workflow module installed
           // Get the current node.
           $node = \Drupal::routeMatch()->getParameter('node');
           if (!empty($node) && is_object($node)) {

--- a/nicsdru_nidirect_theme.theme
+++ b/nicsdru_nidirect_theme.theme
@@ -85,7 +85,7 @@ function _audit_link($type, $dt, $nid) {
         $link_object = Link::createFromRoute($audit_button_text, 'nidirect_workflow.audit_controller_content_audit', ['nid' => $nid], $options);
       }
       if ($link_object) {
-        return $link_object->toString()->__toString();
+        return $link_object->toRenderable();
       } else {
         return "";
       }

--- a/nicsdru_nidirect_theme.theme
+++ b/nicsdru_nidirect_theme.theme
@@ -33,8 +33,8 @@ function nicsdru_nidirect_theme_preprocess_field(&$variables) {
               $next_review_date = $node->get('field_next_review_date')->value;
               if (strtotime($next_review_date) < strtotime("now")) {
                 // Next review date is in the past,
-                // so this node is due for audit - display the audit link
-                // if the user is allowed to see it.
+                // so this node is due for audit - display node edit link
+                // (if the user is allowed to see it).
                 $account = User::load(\Drupal::currentUser()->id());
                 if ($account->hasPermission('audit content')) {
                   $audit_button_text = \Drupal::config('nidirect_workflow.auditsettings')->get('audit_button_text');
@@ -60,7 +60,7 @@ function nicsdru_nidirect_theme_preprocess_field(&$variables) {
               if (strtotime($next_audit_date) < strtotime("now")) {
                 // Next audit date is in the past,
                 // so this node is due for audit - display the audit link
-                // if the user is allowed to see it.
+                // (if the user is allowed to see it).
                 $account = User::load(\Drupal::currentUser()->id());
                 if ($account->hasPermission('audit content')) {
                   $audit_button_text = \Drupal::config('nidirect_workflow.auditsettings')->get('audit_button_text');

--- a/nicsdru_nidirect_theme.theme
+++ b/nicsdru_nidirect_theme.theme
@@ -17,7 +17,7 @@ function nicsdru_nidirect_theme_preprocess_field(&$variables) {
     && isset($variables['element']['#entity_type'])
     && ($variables['element']['#entity_type'] == 'node')
   ) {
-    // We are only ineterested in certain content types.
+    // We are only interested in certain content types.
     $content_type = $variables['element']['#bundle'];
     switch ($content_type) {
       case 'health_condition':
@@ -71,7 +71,13 @@ function _audit_link($type, $dt, $nid) {
       $audit_button_text = \Drupal::config('nidirect_workflow.auditsettings')->get('audit_button_text');
       $audit_button_hover_text = \Drupal::config('nidirect_workflow.auditsettings')->get('audit_button_hover_text');
       // Set up common attributes for links.
-      $options = ['attributes' => ['rel' => 'nofollow', 'title' => $audit_button_hover_text, 'class' => 'audit_link']];
+      $options = [
+        'attributes' => [
+          'rel' => 'nofollow',
+          'title' => $audit_button_hover_text,
+          'class' => 'audit_link',
+        ],
+      ];
       $link_object = NULL;
       if ($type == 'health_condition') {
         // For health conditions, just send the user to the node edit
@@ -85,8 +91,10 @@ function _audit_link($type, $dt, $nid) {
         $link_object = Link::createFromRoute($audit_button_text, 'nidirect_workflow.audit_controller_content_audit', ['nid' => $nid], $options);
       }
       if ($link_object) {
+        // Return render array.
         return $link_object->toRenderable();
-      } else {
+      }
+      else {
         return "";
       }
     }

--- a/nicsdru_nidirect_theme.theme
+++ b/nicsdru_nidirect_theme.theme
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @file
+ * Functions to support theming in the nicsdru_nidirect_theme theme.
+ */
+
+
+/**
+ * Implements hook_preprocess_field().
+ */
+function nicsdru_nidirect_theme_preprocess_field(&$variables)
+{
+  // Implement audit link.
+  if (isset($variables['element'])
+    && isset($variables['element']['#entity_type'])
+    && ($variables['element']['#entity_type'] == 'node')
+  ) {
+    // Only start this processing if the 'nidirect_workflow' module is installed.
+    if (\Drupal::service('module_handler')->moduleExists('nidirect_workflow')) {
+      $content_type = $variables['element']['#bundle'];
+      switch ($content_type) {
+        case 'health_condition':
+          // ** check to see if this node is due for audit
+          // ** check to see if workflow module installed
+          // Get the current node.
+          $node = \Drupal::routeMatch()->getParameter('node');
+          if (!empty($node) && is_object($node)) {
+            $nid = $node->id();
+            if (!empty($nid)) {
+              $variables['audit_link'] = '<a href="/nidirect_workflow/content_audit/' . $nid . '?destination=node/' . $nid . '" title="Click this link to indicate you have checked this content for accuracy and relevance" class="flag unflag-action flag-link-confirm" rel="nofollow">Audit this published content</a>';
+            }
+          }
+          break;
+
+        case 'article':
+        case 'contact':
+        case 'page':
+          // ** check to see if this node is due for audit
+          // ** check to see if workflow module installed
+          // Get the current node.
+          $node = \Drupal::routeMatch()->getParameter('node');
+          if (!empty($node) && is_object($node)) {
+            $nid = $node->id();
+            if (!empty($nid)) {
+              $variables['audit_link'] = '<a href="/nidirect_workflow/content_audit/' . $nid . '?destination=node/' . $nid . '" title="Click this link to indicate you have checked this content for accuracy and relevance" class="flag unflag-action flag-link-confirm" rel="nofollow">Audit this published content</a>';
+            }
+          }
+          break;
+      }
+    }
+  }
+}

--- a/nicsdru_nidirect_theme.theme
+++ b/nicsdru_nidirect_theme.theme
@@ -35,7 +35,10 @@ function nicsdru_nidirect_theme_preprocess_field(&$variables) {
                 // so this node is due for audit - display the audit link.
                 $config = \Drupal::config('nidirect_workflow.auditsettings');
                 $audit_button_text = $config->get('audit_button_text');
-                $variables['audit_link'] = '<a href="/nidirect_workflow/content_audit/' . $nid . '?destination=node/' . $nid . '" title="Click this link to indicate you have checked this content for accuracy and relevance" class="flag unflag-action flag-link-confirm" rel="nofollow">' . $audit_button_text . '</a>';
+                $audit_button_hover_text = $config->get('audit_button_hover_text');
+                $variables['audit_link'] = '<a href="/nidirect_workflow/content_audit/' . $nid;
+                $variables['audit_link'] .= '?destination=node/' . $nid . '" title="' . $audit_button_hover_text;
+                $variables['audit_link'] .= '" class="flag unflag-action flag-link-confirm" rel="nofollow">' . $audit_button_text . '</a>';
               }
             }
           }

--- a/nicsdru_nidirect_theme.theme
+++ b/nicsdru_nidirect_theme.theme
@@ -5,6 +5,8 @@
  * Functions to support theming in the nicsdru_nidirect_theme theme.
  */
 
+use Drupal\user\Entity\User;
+
 /**
  * Implements hook_preprocess_field().
  */
@@ -20,6 +22,31 @@ function nicsdru_nidirect_theme_preprocess_field(&$variables) {
       $content_type = $variables['element']['#bundle'];
       switch ($content_type) {
         case 'health_condition':
+          // For health conditions, just send the user to the node edit
+          // form, where they can set the 'next review date' to a date
+          // in the future to remove this node from the 'needs audit' view.
+          $node = \Drupal::routeMatch()->getParameter('node');
+          if (!empty($node) && is_object($node)) {
+            $nid = $node->id();
+            if (!empty($nid)) {
+              // See if audit is due.
+              $next_review_date = $node->get('field_next_review_date')->value;
+              if (strtotime($next_review_date) < strtotime("now")) {
+                // Next review date is in the past,
+                // so this node is due for audit - display the audit link
+                // if the user is allowed to see it.
+                $account = User::load(\Drupal::currentUser()->id());
+                if ($account->hasPermission('audit content')) {
+                  $audit_button_text = \Drupal::config('nidirect_workflow.auditsettings')->get('audit_button_text');
+                  $audit_button_hover_text = \Drupal::config('nidirect_workflow.auditsettings')->get('audit_button_hover_text');
+                  $variables['audit_link'] = '<a href="/node/' . $nid . '/edit" title="' . $audit_button_hover_text;
+                  $variables['audit_link'] .= '" class="flag unflag-action flag-link-confirm" rel="nofollow">' . $audit_button_text . '</a>';
+                }
+              }
+            }
+          }
+          break;
+
         case 'article':
         case 'contact':
         case 'page':
@@ -32,13 +59,16 @@ function nicsdru_nidirect_theme_preprocess_field(&$variables) {
               $next_audit_date = $node->get('field_next_audit_due')->value;
               if (strtotime($next_audit_date) < strtotime("now")) {
                 // Next audit date is in the past,
-                // so this node is due for audit - display the audit link.
-                $config = \Drupal::config('nidirect_workflow.auditsettings');
-                $audit_button_text = $config->get('audit_button_text');
-                $audit_button_hover_text = $config->get('audit_button_hover_text');
-                $variables['audit_link'] = '<a href="/nidirect_workflow/content_audit/' . $nid;
-                $variables['audit_link'] .= '?destination=node/' . $nid . '" title="' . $audit_button_hover_text;
-                $variables['audit_link'] .= '" class="flag unflag-action flag-link-confirm" rel="nofollow">' . $audit_button_text . '</a>';
+                // so this node is due for audit - display the audit link
+                // if the user is allowed to see it.
+                $account = User::load(\Drupal::currentUser()->id());
+                if ($account->hasPermission('audit content')) {
+                  $audit_button_text = \Drupal::config('nidirect_workflow.auditsettings')->get('audit_button_text');
+                  $audit_button_hover_text = \Drupal::config('nidirect_workflow.auditsettings')->get('audit_button_hover_text');
+                  $variables['audit_link'] = '<a href="/nidirect_workflow/content_audit/' . $nid;
+                  $variables['audit_link'] .= '?destination=node/' . $nid . '" title="' . $audit_button_hover_text;
+                  $variables['audit_link'] .= '" class="flag unflag-action flag-link-confirm" rel="nofollow">' . $audit_button_text . '</a>';
+                }
               }
             }
           }

--- a/nicsdru_nidirect_theme.theme
+++ b/nicsdru_nidirect_theme.theme
@@ -33,7 +33,9 @@ function nicsdru_nidirect_theme_preprocess_field(&$variables) {
               if (strtotime($next_audit_date) < strtotime("now")) {
                 // Next audit date is in the past,
                 // so this node is due for audit - display the audit link.
-                $variables['audit_link'] = '<a href="/nidirect_workflow/content_audit/' . $nid . '?destination=node/' . $nid . '" title="Click this link to indicate you have checked this content for accuracy and relevance" class="flag unflag-action flag-link-confirm" rel="nofollow">Audit this published content</a>';
+                $config = \Drupal::config('nidirect_workflow.auditsettings');
+                $audit_button_text = $config->get('audit_button_text');
+                $variables['audit_link'] = '<a href="/nidirect_workflow/content_audit/' . $nid . '?destination=node/' . $nid . '" title="Click this link to indicate you have checked this content for accuracy and relevance" class="flag unflag-action flag-link-confirm" rel="nofollow">' . $audit_button_text . '</a>';
               }
             }
           }

--- a/nicsdru_nidirect_theme.theme
+++ b/nicsdru_nidirect_theme.theme
@@ -5,6 +5,7 @@
  * Functions to support theming in the nicsdru_nidirect_theme theme.
  */
 
+use Drupal\Core\Link;
 use Drupal\user\Entity\User;
 
 /**
@@ -16,63 +17,77 @@ function nicsdru_nidirect_theme_preprocess_field(&$variables) {
     && isset($variables['element']['#entity_type'])
     && ($variables['element']['#entity_type'] == 'node')
   ) {
-    // Only start this processing if the 'nidirect_workflow'
-    // module is installed.
-    if (\Drupal::service('module_handler')->moduleExists('nidirect_workflow')) {
-      $content_type = $variables['element']['#bundle'];
-      switch ($content_type) {
-        case 'health_condition':
-          // For health conditions, just send the user to the node edit
-          // form, where they can set the 'next review date' to a date
-          // in the future to remove this node from the 'needs audit' view.
-          $node = \Drupal::routeMatch()->getParameter('node');
-          if (!empty($node) && is_object($node)) {
-            $nid = $node->id();
-            if (!empty($nid)) {
-              // See if audit is due.
-              $next_review_date = $node->get('field_next_review_date')->value;
-              if (strtotime($next_review_date) < \Drupal::time()->getCurrentTime()) {
-                // Next review date is in the past,
-                // so this node is due for audit - display node edit link
-                // (if the user is allowed to see it).
-                $account = User::load(\Drupal::currentUser()->id());
-                if ($account->hasPermission('audit content')) {
-                  $audit_button_text = \Drupal::config('nidirect_workflow.auditsettings')->get('audit_button_text');
-                  $audit_button_hover_text = \Drupal::config('nidirect_workflow.auditsettings')->get('audit_button_hover_text');
-                  $variables['audit_link'] = '<a href="/node/' . $nid . '/edit" title="' . $audit_button_hover_text;
-                  $variables['audit_link'] .= '" class="flag unflag-action flag-link-confirm" rel="nofollow">' . $audit_button_text . '</a>';
-                }
-              }
-            }
-          }
-          break;
+    // We are only ineterested in certain content types.
+    $content_type = $variables['element']['#bundle'];
+    switch ($content_type) {
+      case 'health_condition':
+        _build_audit_link('health_condition', $variables);
+        break;
 
-        case 'article':
-        case 'contact':
-        case 'page':
-          // Get the current node.
-          $node = \Drupal::routeMatch()->getParameter('node');
-          if (!empty($node) && is_object($node)) {
-            $nid = $node->id();
-            if (!empty($nid)) {
-              // See if audit is due.
-              $next_audit_date = $node->get('field_next_audit_due')->value;
-              if (strtotime($next_audit_date) < \Drupal::time()->getCurrentTime()) {
-                // Next audit date is in the past,
-                // so this node is due for audit - display the audit link
-                // (if the user is allowed to see it).
-                $account = User::load(\Drupal::currentUser()->id());
-                if ($account->hasPermission('audit content')) {
-                  $audit_button_text = \Drupal::config('nidirect_workflow.auditsettings')->get('audit_button_text');
-                  $audit_button_hover_text = \Drupal::config('nidirect_workflow.auditsettings')->get('audit_button_hover_text');
-                  $variables['audit_link'] = '<a href="/nidirect_workflow/content_audit/' . $nid;
-                  $variables['audit_link'] .= '?destination=node/' . $nid . '" title="' . $audit_button_hover_text;
-                  $variables['audit_link'] .= '" class="flag unflag-action flag-link-confirm" rel="nofollow">' . $audit_button_text . '</a>';
-                }
-              }
-            }
-          }
-          break;
+      case 'article':
+      case 'contact':
+      case 'page':
+        _build_audit_link('article', $variables);
+        break;
+    }
+  }
+}
+
+/**
+ * Top level function to build audit links.
+ */
+function _build_audit_link($type, &$variables) {
+  // Only start this processing if the 'nidirect_workflow'
+  // module is installed.
+  if (\Drupal::service('module_handler')->moduleExists('nidirect_workflow')) {
+    // Get the current node.
+    $node = \Drupal::routeMatch()->getParameter('node');
+    if (!empty($node)) {
+      $nid = $node->id();
+      if (!empty($nid)) {
+        if ($type == 'health_condition') {
+          $variables['audit_link'] = _audit_link($type, $node->get('field_next_review_date')->value, $nid);
+        }
+        else {
+          // This will be an article, contact or page.
+          $variables['audit_link'] = _audit_link($type, $node->get('field_next_audit_due')->value, $nid);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Utility function to build the audit link html.
+ */
+function _audit_link($type, $dt, $nid) {
+  if (strtotime($dt) < \Drupal::time()->getCurrentTime()) {
+    // Next review date is in the past,
+    // so this node is due for audit - display node edit link
+    // (if the user is allowed to see it).
+    $account = User::load(\Drupal::currentUser()->id());
+    if ($account->hasPermission('audit content')) {
+      // Retrieve audit text from config.
+      $audit_button_text = \Drupal::config('nidirect_workflow.auditsettings')->get('audit_button_text');
+      $audit_button_hover_text = \Drupal::config('nidirect_workflow.auditsettings')->get('audit_button_hover_text');
+      // Set up common attributes for links.
+      $options = ['attributes' => ['rel' => 'nofollow', 'title' => $audit_button_hover_text, 'class' => 'audit_link']];
+      $link_object = NULL;
+      if ($type == 'health_condition') {
+        // For health conditions, just send the user to the node edit
+        // form, where they can set the 'next review date' to a date
+        // in the future to remove this node from the 'needs audit' view.
+        $link_object = Link::createFromRoute($audit_button_text, 'entity.node.edit_form', ['node' => $nid], $options);
+      }
+      else {
+        // For articles, contacts and pages send the user
+        // to the 'content audit' page.
+        $link_object = Link::createFromRoute($audit_button_text, 'nidirect_workflow.audit_controller_content_audit', ['nid' => $nid], $options);
+      }
+      if ($link_object) {
+        return $link_object->toString()->__toString();
+      } else {
+        return "";
       }
     }
   }

--- a/nicsdru_nidirect_theme.theme
+++ b/nicsdru_nidirect_theme.theme
@@ -31,7 +31,7 @@ function nicsdru_nidirect_theme_preprocess_field(&$variables) {
             if (!empty($nid)) {
               // See if audit is due.
               $next_review_date = $node->get('field_next_review_date')->value;
-              if (strtotime($next_review_date) < strtotime("now")) {
+              if (strtotime($next_review_date) < \Drupal::time()->getCurrentTime()) {
                 // Next review date is in the past,
                 // so this node is due for audit - display node edit link
                 // (if the user is allowed to see it).
@@ -57,7 +57,7 @@ function nicsdru_nidirect_theme_preprocess_field(&$variables) {
             if (!empty($nid)) {
               // See if audit is due.
               $next_audit_date = $node->get('field_next_audit_due')->value;
-              if (strtotime($next_audit_date) < strtotime("now")) {
+              if (strtotime($next_audit_date) < \Drupal::time()->getCurrentTime()) {
                 // Next audit date is in the past,
                 // so this node is due for audit - display the audit link
                 // (if the user is allowed to see it).

--- a/templates/field/field--node--body--article.html.twig
+++ b/templates/field/field--node--body--article.html.twig
@@ -1,0 +1,59 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{%
+  set title_classes = [
+    label_display == 'visually_hidden' ? 'visually-hidden',
+  ]
+%}
+{{ audit_link|raw }}
+{% if label_hidden %}
+  {% if multiple %}
+      {% for item in items %}
+        {{ item.content }}
+      {% endfor %}
+  {% else %}
+    {% for item in items %}
+      {{ item.content }}
+    {% endfor %}
+  {% endif %}
+{% else %}
+    {% for item in items %}
+      {{ item.content }}
+    {% endfor %}
+{% endif %}

--- a/templates/field/field--node--body--article.html.twig
+++ b/templates/field/field--node--body--article.html.twig
@@ -41,7 +41,14 @@
     label_display == 'visually_hidden' ? 'visually-hidden',
   ]
 %}
-{{ audit_link|raw }}
+{#
+* Audit link added in here so that it doesn't get forgotten.
+*
+* Note also that this entire field template was added for the purposes of displaying
+* the audit link - it may be decided as we progress that there is a better way to
+* theme the content types.
+#}
+{{ audit_link }}
 {% if label_hidden %}
   {% if multiple %}
       {% for item in items %}

--- a/templates/field/field--node--body--contact.html.twig
+++ b/templates/field/field--node--body--contact.html.twig
@@ -41,6 +41,13 @@
     label_display == 'visually_hidden' ? 'visually-hidden',
   ]
 %}
+{#
+* Audit link added in here so that it doesn't get forgotten.
+*
+* Note also that this entire field template was added for the purposes of displaying
+* the audit link - it may be decided as we progress that there is a better way to
+* theme the content types.
+#}
 {{ audit_link|raw }}
 {% if label_hidden %}
   {% if multiple %}

--- a/templates/field/field--node--body--contact.html.twig
+++ b/templates/field/field--node--body--contact.html.twig
@@ -1,0 +1,59 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{%
+  set title_classes = [
+    label_display == 'visually_hidden' ? 'visually-hidden',
+  ]
+%}
+{{ audit_link|raw }}
+{% if label_hidden %}
+  {% if multiple %}
+      {% for item in items %}
+        {{ item.content }}
+      {% endfor %}
+  {% else %}
+    {% for item in items %}
+      {{ item.content }}
+    {% endfor %}
+  {% endif %}
+{% else %}
+    {% for item in items %}
+      {{ item.content }}
+    {% endfor %}
+{% endif %}

--- a/templates/field/field--node--body--contact.html.twig
+++ b/templates/field/field--node--body--contact.html.twig
@@ -48,7 +48,7 @@
 * the audit link - it may be decided as we progress that there is a better way to
 * theme the content types.
 #}
-{{ audit_link|raw }}
+{{ audit_link }}
 {% if label_hidden %}
   {% if multiple %}
       {% for item in items %}

--- a/templates/field/field--node--body--health-condition.html.twig
+++ b/templates/field/field--node--body--health-condition.html.twig
@@ -41,6 +41,13 @@
     label_display == 'visually_hidden' ? 'visually-hidden',
   ]
 %}
+{#
+* Audit link added in here so that it doesn't get forgotten.
+*
+* Note also that this entire field template was added for the purposes of displaying
+* the audit link - it may be decided as we progress that there is a better way to
+* theme the content types.
+#}
 {{ audit_link|raw }}
 {% if label_hidden %}
   {% if multiple %}

--- a/templates/field/field--node--body--health-condition.html.twig
+++ b/templates/field/field--node--body--health-condition.html.twig
@@ -1,0 +1,59 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{%
+  set title_classes = [
+    label_display == 'visually_hidden' ? 'visually-hidden',
+  ]
+%}
+{{ audit_link|raw }}
+{% if label_hidden %}
+  {% if multiple %}
+      {% for item in items %}
+        {{ item.content }}
+      {% endfor %}
+  {% else %}
+    {% for item in items %}
+      {{ item.content }}
+    {% endfor %}
+  {% endif %}
+{% else %}
+    {% for item in items %}
+      {{ item.content }}
+    {% endfor %}
+{% endif %}

--- a/templates/field/field--node--body--health-condition.html.twig
+++ b/templates/field/field--node--body--health-condition.html.twig
@@ -48,7 +48,7 @@
 * the audit link - it may be decided as we progress that there is a better way to
 * theme the content types.
 #}
-{{ audit_link|raw }}
+{{ audit_link }}
 {% if label_hidden %}
   {% if multiple %}
       {% for item in items %}

--- a/templates/field/field--node--body--page.html.twig
+++ b/templates/field/field--node--body--page.html.twig
@@ -41,6 +41,13 @@
     label_display == 'visually_hidden' ? 'visually-hidden',
   ]
 %}
+{#
+* Audit link added in here so that it doesn't get forgotten.
+*
+* Note also that this entire field template was added for the purposes of displaying
+* the audit link - it may be decided as we progress that there is a better way to
+* theme the content types.
+#}
 {{ audit_link|raw }}
 {% if label_hidden %}
   {% if multiple %}

--- a/templates/field/field--node--body--page.html.twig
+++ b/templates/field/field--node--body--page.html.twig
@@ -1,0 +1,59 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{%
+  set title_classes = [
+    label_display == 'visually_hidden' ? 'visually-hidden',
+  ]
+%}
+{{ audit_link|raw }}
+{% if label_hidden %}
+  {% if multiple %}
+      {% for item in items %}
+        {{ item.content }}
+      {% endfor %}
+  {% else %}
+    {% for item in items %}
+      {{ item.content }}
+    {% endfor %}
+  {% endif %}
+{% else %}
+    {% for item in items %}
+      {{ item.content }}
+    {% endfor %}
+{% endif %}

--- a/templates/field/field--node--body--page.html.twig
+++ b/templates/field/field--node--body--page.html.twig
@@ -48,7 +48,7 @@
 * the audit link - it may be decided as we progress that there is a better way to
 * theme the content types.
 #}
-{{ audit_link|raw }}
+{{ audit_link }}
 {% if label_hidden %}
   {% if multiple %}
       {% for item in items %}


### PR DESCRIPTION
- Added preprocess function to add 'audit this content' link to articles, contacts, pages or health condition nodes when appropriate
- Added templates for 'body' field of each content type to show the audit link. (These will obviously change in the future and the audit link may need to be added to a different field or template, but have added in here as a reminder so that it doesn't get forgotten)