### PR TITLE
D8NID-158 health conditions search results

### DIFF
--- a/templates/block/block--views-exposed-filter-block--health-conditions-search-page.html.twig
+++ b/templates/block/block--views-exposed-filter-block--health-conditions-search-page.html.twig
@@ -1,0 +1,23 @@
+{#
+/**
+* @file
+* Block template for exposed filter form attached to find a GP practice view.
+#}
+{%
+set classes = [
+'block',
+'block-' ~ configuration.provider|clean_class,
+'block-' ~ plugin_id|clean_class,
+]
+%}
+<div{{ attributes.addClass(classes) }}>
+{% if label %}
+<h2{{ title_attributes }}>{{ label }}</h2>
+{% endif %}
+Search by health condition or symptoms.
+{% block content %}
+<div{{ content_attributes.addClass('content') }}>
+{{ content }}
+</div>
+{% endblock %}
+</div>

--- a/templates/content/node--health-condition--search-result.html.twig
+++ b/templates/content/node--health-condition--search-result.html.twig
@@ -17,7 +17,7 @@
 </p>
 <div class="further-info">
   <p class="extract">
-    {{ content.field_summary|render|striptags|trim }}
+    {{ content.field_summary }}
     <a href="{{ url }}">Find out more<span class="element-invisible"> about {{ label }}</span></a>
   </p>
 </div>

--- a/templates/content/node--health-condition--search-result.html.twig
+++ b/templates/content/node--health-condition--search-result.html.twig
@@ -1,0 +1,30 @@
+{#
+/**
+ * @file
+ * Theme override to display a health condition node in search result view mode.
+#}
+<h3><a href="{{ url }}">{{ label }}</a></h3>
+<p class="symptoms">
+  <span class="label-inline">Symptoms include:</span>
+  <span class="values">
+  {% for i in 1..4 %}
+    {% set symptom = attribute(content, 'field_hc_primary_symptom_' ~ i) | render | striptags %}
+    {% if symptom is not empty %}
+      <span class="meta">{{ symptom }}</span>
+    {% endif %}
+  {% endfor %}
+  </span>
+</p>
+<div class="further-info">
+  <p class="extract">
+    {{ content.field_summary|render|striptags|trim }}
+    <a href="{{ url }}">Find out more<span class="element-invisible"> about {{ label }}</span></a>
+  </p>
+</div>
+{{ content | without(
+  'field_summary',
+  'field_hc_primary_symptom_1',
+  'field_hc_primary_symptom_2',
+  'field_hc_primary_symptom_3',
+  'field_hc_primary_symptom_4')
+}}

--- a/templates/content/node--health-condition--search-result.html.twig
+++ b/templates/content/node--health-condition--search-result.html.twig
@@ -21,8 +21,16 @@
     <a href="{{ url }}">Find out more<span class="element-invisible"> about {{ label }}</span></a>
   </p>
 </div>
+{% if content.related_conditions is not empty %}
+<div class="further-info">
+  <h4>Related conditions</h4>
+  {{ content.related_conditions }}
+</div>
+{% endif %}
 {{ content | without(
   'field_summary',
+  'related_conditions',
+  'field_related_conditions',
   'field_hc_primary_symptom_1',
   'field_hc_primary_symptom_2',
   'field_hc_primary_symptom_3',


### PR DESCRIPTION
Templates for exposed filter block and search results view of health condition nodes.

New PR to cover small refinement to remove twig filters in `ec3986d`