### PR TITLE
Add template for publication node search_view mode

### DIFF
--- a/templates/content/node--publication--search-result.html.twig
+++ b/templates/content/node--publication--search-result.html.twig
@@ -1,0 +1,13 @@
+{#
+/**
+ * @file
+ * Theme override to display a publication node in search result view mode.
+#}
+<h3><a href="{{ url }}">{{ label }}</a></h3>
+<p class="meta">
+  <span class="label-inline">{{ content.field_published_date | field_label }}</span>
+  <span class="date-display-single">{{ content.field_published_date | field_value }}</span>
+  <span class="metaItemList">{{ content.field_publication_type | field_value }}</span>
+</p>
+
+{{ content | without('field_published_date', 'field_publication_type') }}

--- a/templates/content/node--publication--search-result.html.twig
+++ b/templates/content/node--publication--search-result.html.twig
@@ -7,7 +7,7 @@
 <p class="meta">
   <span class="label-inline">{{ content.field_published_date | field_label }}</span>
   <span class="date-display-single">{{ content.field_published_date | field_value }}</span>
-  <span class="metaItemList">{{ content.field_publication_type | field_value }}</span>
+  <span class="meta-item-list">{{ content.field_publication_type | field_value }}</span>
 </p>
 
 {{ content | without('field_published_date', 'field_publication_type') }}


### PR DESCRIPTION
Requires https://www.drupal.org/project/twig_field_value enabled for the twig filters used to work. These make it really easy to pick out field labels/values directly in the template rather than fishing about in the preprocess array.