### PR TITLE
Article teaser views

### DIFF
--- a/templates/block/block--nidirect-article-teasers-by-topic.html.twig
+++ b/templates/block/block--nidirect-article-teasers-by-topic.html.twig
@@ -26,13 +26,7 @@
  */
 #}
 <div{{ attributes }}>
-  {{ title_prefix }}
-  {% if label %}
-    <h2{{ title_attributes }}>{{ label }}</h2>
-  {% endif %}
-  {{ title_suffix }}
   {% block content %}
-    {{ devel_breakpoint() }}
     {% for article in content.nidirect_article_teasers_by_topic %}
       <div>
         <h2>{{ article.title_link }}</h2>

--- a/templates/block/block--nidirect-article-teasers-by-topic.html.twig
+++ b/templates/block/block--nidirect-article-teasers-by-topic.html.twig
@@ -1,0 +1,43 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+<div{{ attributes }}>
+  {{ title_prefix }}
+  {% if label %}
+    <h2{{ title_attributes }}>{{ label }}</h2>
+  {% endif %}
+  {{ title_suffix }}
+  {% block content %}
+    {{ devel_breakpoint() }}
+    {% for article in content.nidirect_article_teasers_by_topic %}
+      <div>
+        <h2>{{ article.title_link }}</h2>
+        <div>{{ article.summary_text }}{{ article.more_link }}</div>
+      </div>
+    {% endfor %}
+  {% endblock %}
+</div>

--- a/templates/block/block--nidirect-article-teasers-by-topic.html.twig
+++ b/templates/block/block--nidirect-article-teasers-by-topic.html.twig
@@ -33,5 +33,7 @@
         <div>{{ article.summary_text }}{{ article.more_link }}</div>
       </div>
     {% endfor %}
+    {# Bubble cache tags up #}
+    {%  set catch_cache = content.nidirect_article_teasers_by_topic|render %}
   {% endblock %}
 </div>


### PR DESCRIPTION
New template to display a custom block of article teasers on a campaign / landing page.

See related PRs:
https://github.com/dof-dss/nidirect-site-modules/pull/60
https://github.com/dof-dss/nidirect-drupal/pull/132