### PR TITLE
Replaced fixed title rendering with a call to render a page title blocks

### DIFF
--- a/templates/content/taxonomy-term--site-themes.html.twig
+++ b/templates/content/taxonomy-term--site-themes.html.twig
@@ -24,15 +24,10 @@
  */
 #}
 <div{{ attributes }}>
+  {{ drupal_block('page_title_block', wrapper=false) }}
   {% if information_services_output is defined %}
-    <h1>{{ name }}</h1>
     {{ information_services_output }}
   {%  else %}
-    {{ title_prefix }}
-    {% if not page %}
-      <h2><a href="{{ url }}">{{ name }}</a></h2>
-    {% endif %}
-    {{ title_suffix }}
     {{ content }}
   {%  endif %}
 </div>


### PR DESCRIPTION
As per node templates: sets all the conditional logic on the block config itself and leaves the templates clear and simple.