### PR TITLE
Add cut down, static version of a page for branded HTTP 500 responses

### DIFF
--- a/500.html
+++ b/500.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr" prefix="og: https://ogp.me/ns#" class="no-js">
+<head>
+  <title>Internal Server Error | nidirect</title>
+  <meta charset="utf-8" />
+  <link rel="shortlink" href="https://www.nidirect.gov.uk" />
+  <meta property="og:site_name" content="nidirect" />
+  <link rel="canonical" href="https://www.nidirect.gov.uk/" />
+  <meta name="Generator" content="Drupal 8 (https://www.drupal.org)" />
+  <meta name="MobileOptimized" content="width" />
+  <meta name="HandheldFriendly" content="true" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="apple-touch-icon" sizes="180x180" href="images/favicons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="images/favicons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="images/favicons/favicon-16x16.png">
+  <link rel="manifest" href="images/favicons/site.webmanifest">
+  <link rel="mask-icon" href="images/favicons/safari-pinned-tab.svg" color="#0c1e63">
+  <link rel="shortcut icon" href="images/favicons/favicon.ico">
+  <meta name="apple-mobile-web-app-title" content="nidirect">
+  <meta name="application-name" content="nidirect">
+  <meta name="msapplication-TileColor" content="#ffffff">
+  <meta name="msapplication-TileImage" content="images/favicons/mstile-144x144.png">
+  <meta name="msapplication-config" content="images/favicons/browserconfig.xml">
+  <meta name="theme-color" content="#ffffff">
+  <link rel="stylesheet" media="all" href="css/1_base/root.css" />
+  <link rel="stylesheet" media="all" href="css/1_base/html5.css" />
+  <link rel="stylesheet" media="all" href="css/1_base/headings.css" />
+  <link rel="stylesheet" media="all" href="css/1_base/text.css" />
+  <link rel="stylesheet" media="all" href="css/2_layouts/layouts-common.css" />
+  <link rel="stylesheet" media="all" href="css/3_components/layout/header.css" />
+  <link rel="stylesheet" media="all" href="css/3_components/layout/footer.css" />
+  <link rel="stylesheet" media="all" href="css/3_components/navigation/nav-menu.css" />
+  <link rel="stylesheet" media="all" href="css/3_components/navigation/main-menu.css" />
+  <link rel="stylesheet" media="all" href="css/3_components/navigation/footer-menu.css" />
+  <link rel="stylesheet" media="all" href="css/3_components/block/site-logo.css" />
+</head>
+<body class="path-admin">
+<?xml version="1.0" encoding="utf-8"?>
+<svg aria-hidden="true" style="position: absolute; width: 0; height: 0; display:none;" width="0" height="0" xmlns="http://www.w3.org/2000/svg">
+  <symbol id="arrow" viewBox="0 0 15 25"><path d="M15 12.5L2.5 25 0 22.5l10-10-10-10L2.5 0z"/>
+  </symbol>
+  <symbol id="elink" viewBox="0 0 14 11"><path d="M0 3h2V0h12v8h-2v3H0zm13-2H3v6h10zM2 4H1v4h1zm-1 6h10V8H1z"/>
+  </symbol></svg>
+<div class="dialog-off-canvas-main-canvas" role="presentation" data-off-canvas-main-canvas>
+  <header class="header">
+    <div class="layout-header--logo" role="presentation">
+      <a href="/" title="Home" rel="home"><img class="site-logo" src="logo.svg" alt="Home" /></a></div>
+  </header>
+  <nav class="main-menu  clearfix" aria-labelledby="block-mainnavigation-menu" id="block-mainnavigation">
+    <div class="nav-main">
+      <ul class="nav-menu">
+        <li class="nav-item"><a href="/" class="nav-link" data-drupal-link-system-path="&lt;front&gt;">Home</a></li>
+        <li class="nav-item"><a href="/news" class="nav-link" data-drupal-link-system-path="news">News</a></li>
+        <li class="nav-item"><a href="/contacts" class="nav-link" data-drupal-link-system-path="contacts">Contacts</a></li>
+        <li class="nav-item"><a href="/information-and-services/help" class="nav-link" data-drupal-link-system-path="taxonomy/term/402">Help</a></li>
+        <li class="nav-item"><a href="/form/site-feedback?s=/500.html" class="nav-link" data-drupal-link-query="{&quot;s&quot;:&quot;\/admin&quot;}" data-drupal-link-system-path="webform/site_feedback">Feedback</a></li>
+      </ul>
+      <aside class="nav-social">
+        <ul class="links">
+          <li><a href="https://twitter.com/nidirect" title="Twitter" rel="noreferrer">Twitter</a></li>
+          <li><a href="https://www.facebook.com/nidirect" title="Facebook" rel="noreferrer">Facebook</a></li>
+          <li><a href="https://www.youtube.com/user/nidirect" title="YouTube" rel="noreferrer">YouTube</a></li>
+          <li><a href="/news-rss.xml" title="RSS">RSS</a></li>
+        </ul>
+      </aside>
+    </div>
+  </nav>
+  <div data-drupal-messages-fallback class="hidden"></div>
+  <main class="container" id="main-content">
+    <h1 class="page-title">Internal server error</h1>
+    <p><strong>Sorry, there was a problem processing the page you wanted.</strong></p>
+    <p>The issue has been logged and will be followed up soon. Please try again later.</p>
+  </main>
+  <footer id="footer" class="footer">
+  <div class="footer-main container" aria-labelledby="block-footer-menu" id="block-footer">
+    <ul class="nav-menu">
+      <li class="nav-item"><a href="/articles/crown-copyright" class="nav-link" data-drupal-link-system-path="node/11440">Crown copyright</a></li>            <li class="nav-item"><a href="/articles/terms-and-conditions" class="nav-link" data-drupal-link-system-path="node/4643">Terms and conditions</a></li>            <li class="nav-item"><a href="/articles/nidirect-web-service-privacy-notice" class="nav-link" data-drupal-link-system-path="node/11439">Privacy</a></li>
+      <li class="nav-item"><a href="/articles/cookies" class="nav-link" data-drupal-link-system-path="node/4644">Cookies</a></li>
+    </ul>
+    <ul class="nav-social">
+      <li><a href="https://twitter.com/nidirect" title="Twitter" rel="noreferrer">Twitter</a></li>
+      <li><a href="https://www.facebook.com/nidirect" title="Facebook" rel="noreferrer">Facebook</a></li>
+      <li><a href="https://www.youtube.com/user/nidirect" title="YouTube" rel="noreferrer">YouTube</a></li>
+      <li><a href="/news-rss.xml" title="RSS">RSS</a></li>
+    </ul>
+  </div>
+
+  <div class="footer-related container" aria-labelledby="block-relatedsites-menu" id="block-relatedsites">
+    <h2 id="block-relatedsites-menu">Related sites</h2>
+    <ul class="nav-menu">
+      <li class="nav-item"><a href="https://gov.uk" class="nav-link">gov.uk</a></li>
+      <li class="nav-item"><a href="https://www.nibusinessinfo.co.uk" class="nav-link" rel="noreferrer">nibusinessinfo.co.uk</a></li>
+    </ul>
+  </div>
+</footer>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Things to note:

- There is no DB access when this page is normally shown, so any dynamic elements cannot be used nor can server processing (eg: Drupal JS/CSS aggregation) be assumed to operate.
- As such the search form is not shown, because it won't work.
- Copy/content can be adjusted easily in the doc if needed.
- Setup will vary depending on the hosting context. Generally you either set your web server ErrorDoc directive to point to the .html file, or you configure your PaaS config to do the same sort of thing.
- Markup changes over time aren't automatically reflected here, so this should be reviewed periodically to ensure it broadly matches the site design.

The file is kept in the nidirect theme rather than the origins theme because it's themed for this site and is not very re-usable across other theme/site contexts.