### PR TITLE
D8NID-631 page title blocks

### DIFF
--- a/nicsdru_nidirect_theme.theme
+++ b/nicsdru_nidirect_theme.theme
@@ -102,6 +102,8 @@ function nicsdru_nidirect_theme_preprocess_page(array &$variables) {
  * Implements hook_preprocess_node().
  */
 function nicsdru_nidirect_theme_preprocess_node(array &$variables) {
+  $variables['show_title'] = TRUE;
+
   switch ($variables['node']->getType()) {
     case "article":
     case "application":
@@ -113,6 +115,13 @@ function nicsdru_nidirect_theme_preprocess_node(array &$variables) {
     case "publication":
       // Change field label to 'Documents'.
       $variables['content']['field_attachment']['#title'] = t('Documents');
+      break;
+
+    case "landing_page":
+    case "page":
+      // Omit the title on these content types; causes trouble with search indexing.
+      // Resolvable with either suitable block config or specific node templates for these types.
+      $variables['show_title'] = FALSE;
       break;
   }
 }

--- a/templates/content/node--full.html.twig
+++ b/templates/content/node--full.html.twig
@@ -71,7 +71,6 @@
  */
 #}
 <article{{ attributes.setAttribute('id', 'main-article').removeAttribute('role') }}>
-  {{ drupal_block('page_title_block', wrapper=false) }}
   {% if  content_attributes is not empty %}
   <div{{ content_attributes }}>
   {% endif %}

--- a/templates/content/node--full.html.twig
+++ b/templates/content/node--full.html.twig
@@ -71,6 +71,9 @@
  */
 #}
 <article{{ attributes.setAttribute('id', 'main-article').removeAttribute('role') }}>
+  {% if show_title %}
+  {{ drupal_block('page_title_block', wrapper=false) }}
+  {% endif %}
   {% if  content_attributes is not empty %}
   <div{{ content_attributes }}>
   {% endif %}


### PR DESCRIPTION
This PR wraps the call to render the page title block in the Twig template with a small preprocess variable. This provides a workaround for Landing pages that would otherwise interrupt the Solr indexing process.

I expect this can be modified/removed once Landing pages are properly tackled in future development work.