### PR TITLE
Preprocess hook and twig for page titles

### DIFF
--- a/nicsdru_nidirect_theme.theme
+++ b/nicsdru_nidirect_theme.theme
@@ -254,7 +254,7 @@ function nicsdru_nidirect_theme_preprocess_block(array &$variables) {
  */
 function nicsdru_nidirect_theme_preprocess_page_title(&$variables) {
 
-  // Preprocess node titles
+  // Preprocess node titles.
   if ($node = \Drupal::routeMatch()->getParameter('node')) {
 
     // By default page titles are visible.

--- a/nicsdru_nidirect_theme.theme
+++ b/nicsdru_nidirect_theme.theme
@@ -250,6 +250,27 @@ function nicsdru_nidirect_theme_preprocess_block(array &$variables) {
 }
 
 /**
+ * Implements hook_preprocess_page_title().
+ */
+function nicsdru_nidirect_theme_preprocess_page_title(&$variables) {
+
+  // Preprocess node titles
+  if ($node = \Drupal::routeMatch()->getParameter('node')) {
+
+    // By default page titles are visible.
+    $variables['title_visible'] = TRUE;
+
+    // Landing pages have a boolean field to control title visibility.
+    if ($node->getType() == 'landing_page') {
+      // Is the title visible?
+      if ($node->field_enable_title->get(0)->value === '0') {
+        $variables['title_visible'] = FALSE;
+      }
+    }
+  }
+}
+
+/**
  * Implements hook_preprocess_field().
  */
 function nicsdru_nidirect_theme_preprocess_field(&$variables) {

--- a/templates/content/page-title.html.twig
+++ b/templates/content/page-title.html.twig
@@ -1,0 +1,24 @@
+{#
+/**
+ * @file
+ * Theme override for page titles.
+ *
+ * Available variables:
+ * - title_attributes: HTML attributes for the page title element.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title: The page title, for use in the actual content.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - title_visible: boolean.
+ */
+#}
+{% set title_classes = [
+  'page-title',
+  title_visible == false ? 'visually-hidden'
+] %}
+{{ title_prefix }}
+{% if title %}
+  <h1{{ title_attributes.addClass(title_classes) }}>{{ title }}</h1>
+{% endif %}
+{{ title_suffix }}

--- a/templates/content/page-title.html.twig
+++ b/templates/content/page-title.html.twig
@@ -11,6 +11,8 @@
  * - title_suffix: Additional output populated by modules, intended to be
  *   displayed after the main title tag that appears in the template.
  * - title_visible: boolean.
+ *
+ * @see nicsdru_nidirect_theme_preprocess_page_title()
  */
 #}
 {% set title_classes = [


### PR DESCRIPTION
Preprocess hook for page titles: initially need this for landing pages to set a title_visible variable based on the value of field_enable_title.

Page title twig: "visually-hidden" class is added to the H1 if title_visible is set to false (by preprocess hook).