### PR TITLE
Twig fix for contextual links

### DIFF
--- a/templates/block/block--inline-block--banner-deep.html.twig
+++ b/templates/block/block--inline-block--banner-deep.html.twig
@@ -27,7 +27,8 @@
 #}
 {% set classes = ['banner', 'banner--deep'] %}
 <div{{ attributes.addClass(classes) }}>
-  {{ title_suffix.contextual_links }}
+  {{ title_prefix }}
+  {{ title_suffix }}
   {% block content %}
     {{ content }}
   {% endblock %}

--- a/templates/block/block--inline-block--card-deck-plain.html.twig
+++ b/templates/block/block--inline-block--card-deck-plain.html.twig
@@ -32,7 +32,8 @@
   'card-deck--landing' ~ card_layout
 ] %}
 <div{{ attributes.addClass(classes) }}>
-  {{ title_suffix.contextual_links }}
+  {{ title_prefix }}
+  {{ title_suffix }}
   {% block content %}
     {{ content.field_plain_cards }}
   {% endblock %}

--- a/templates/block/block--inline-block--card-standard.html.twig
+++ b/templates/block/block--inline-block--card-standard.html.twig
@@ -29,7 +29,8 @@
   {% set label = 'Title not displayed!' %}
 {% endif %}
 <div{{ attributes.addClass('card') }}>
-  {{ title_suffix.contextual_links }}
+  {{ title_prefix }}
+  {{ title_suffix }}
   <a class="card__link" href="{{ content.field_link[0]['#url']|render }}">
     <div class="card__image">{{ content.field_image }}</div>
     <div class="card__content">

--- a/templates/block/block--inline-block--card-wide.html.twig
+++ b/templates/block/block--inline-block--card-wide.html.twig
@@ -29,7 +29,8 @@
   {% set label = 'Title not displayed!' %}
 {% endif %}
 <div{{ attributes.addClass('card') }}>
-  {{ title_suffix.contextual_links }}
+  {{ title_prefix }}
+  {{ title_suffix }}
   <a class="card__link" href="{{ content.field_link[0]['#url']|render }}">
     <div class="card__image">{{ content.field_image }}</div>
     <div class="card__content">

--- a/templates/block/block--nidirect-article-teasers-by-topic.html.twig
+++ b/templates/block/block--nidirect-article-teasers-by-topic.html.twig
@@ -27,7 +27,8 @@
 #}
 {% set classes = ['card-deck--landing', 'card-deck--landing--simple', 'card-deck--landing--x2'] %}
 <div{{ attributes.addClass(classes).setAttribute('role', 'presentation') }}>
-  {{ title_suffix.contextual_links }}
+  {{ title_prefix }}
+  {{ title_suffix }}
   {% block content %}
     {% for article in content.nidirect_article_teasers_by_topic %}
       <article class="card">


### PR DESCRIPTION
Replace {{ title_suffix.contextual_links }} with {{ title_prefix }} {{ title_suffix }} as it is good practice to have these in block templates and still ensures contextual links are output in layout builder.