### PR TITLE
D8NID-811 Show page title on FCL nodes using canonical node route

### DIFF
--- a/nicsdru_nidirect_theme.theme
+++ b/nicsdru_nidirect_theme.theme
@@ -222,6 +222,13 @@ function nicsdru_nidirect_theme_preprocess_node(array &$variables) {
       $variables['attributes']['class'][] = Html::cleanCssIdentifier('ga-main');
       break;
 
+    case "featured_content_list":
+      // Only show the title on the canonical node route.
+      if (\Drupal::routeMatch()->getRouteName() != 'entity.node.canonical') {
+        $variables['show_title'] = FALSE;
+      }
+      break;
+
     case "publication":
       // Change field label to 'Documents'.
       $variables['content']['field_attachment']['#title'] = t('Documents');

--- a/templates/content/node--featured-content-list.html.twig
+++ b/templates/content/node--featured-content-list.html.twig
@@ -7,4 +7,7 @@
  *
  * @see template_preprocess_node()
 #}
+{% if show_title %}
+  {{ drupal_block('page_title_block', wrapper=false) }}
+{% endif %}
 {{ content }}


### PR DESCRIPTION
Examples of differing output below:

Featured items on homepage:

![Screenshot 2020-08-20 at 15 04 12](https://user-images.githubusercontent.com/451261/90781437-8934ea00-e2f6-11ea-87b5-9f40f36db518.png)

Feature items on news listing:

![Screenshot 2020-08-20 at 15 04 32](https://user-images.githubusercontent.com/451261/90781475-8c2fda80-e2f6-11ea-99ec-73fd1f863be6.png)

Featured items canonical node page:

![Screenshot 2020-08-20 at 15 04 36](https://user-images.githubusercontent.com/451261/90781485-8cc87100-e2f6-11ea-8eff-41c4d3b41439.png)

Featured items canonical node page:

![Screenshot 2020-08-20 at 15 04 40](https://user-images.githubusercontent.com/451261/90781494-8cc87100-e2f6-11ea-9cd1-fcb6bc7ae70f.png)
