### PR TITLE
D8NID-847 theme page template adjustments

### DIFF
--- a/templates/content/taxonomy-term--site-themes.html.twig
+++ b/templates/content/taxonomy-term--site-themes.html.twig
@@ -29,7 +29,5 @@
   {% if information_services_output is defined %}
     {{ information_services_output }}
   {%  endif %}
-  {% if content['field_additional_info'] %}
-    {{ content['field_additional_info'] }}
-  {% endif %}
+  {{ content['field_additional_info'] }}
 </div>

--- a/templates/content/taxonomy-term--site-themes.html.twig
+++ b/templates/content/taxonomy-term--site-themes.html.twig
@@ -25,8 +25,11 @@
 #}
 <div{{ attributes.setAttribute('role', 'presentation') }}>
   {{ drupal_block('page_title_block', wrapper=false) }}
-  {{ content }}
+  {{ content | without('field_additional_info') }}
   {% if information_services_output is defined %}
     {{ information_services_output }}
   {%  endif %}
+  {% if content['field_additional_info'] %}
+    {{ content['field_additional_info'] }}
+  {% endif %}
 </div>

--- a/templates/content/taxonomy-term--site-themes.html.twig
+++ b/templates/content/taxonomy-term--site-themes.html.twig
@@ -25,10 +25,8 @@
 #}
 <div{{ attributes.setAttribute('role', 'presentation') }}>
   {{ drupal_block('page_title_block', wrapper=false) }}
+  {{ content }}
   {% if information_services_output is defined %}
     {{ information_services_output }}
-  {%  else %}
-    {{ content }}
   {%  endif %}
-  {{ content['field_additional_info'] }}
 </div>


### PR DESCRIPTION
Ensure we can print any summary and description fields before the main info + services list.

See https://github.com/dof-dss/nidirect-drupal/pull/410 for config.