### PR TITLE
Omit the title on landing pages.

### DIFF
--- a/nicsdru_nidirect_theme.theme
+++ b/nicsdru_nidirect_theme.theme
@@ -263,6 +263,7 @@ function nicsdru_nidirect_theme_preprocess_node(array &$variables) {
       $variables['content']['field_attachment']['#title'] = t('Documents');
       break;
 
+    case "landing_page":
     case "page":
       // Omit the title on these content types; causes trouble with search
       // indexing. Resolvable with either suitable block config or specific


### PR DESCRIPTION
Search API indexes landing pages as rendered entities; if there is no title then the drupal_block call in the node-full template will fail causing an indexing batch fail.