### PR TITLE
Landing page titles

### DIFF
--- a/nicsdru_nidirect_theme.theme
+++ b/nicsdru_nidirect_theme.theme
@@ -263,6 +263,7 @@ function nicsdru_nidirect_theme_preprocess_node(array &$variables) {
       $variables['content']['field_attachment']['#title'] = t('Documents');
       break;
 
+    case "landing_page":
     case "page":
       // Omit the title on these content types; causes trouble with search
       // indexing. Resolvable with either suitable block config or specific
@@ -334,21 +335,6 @@ function nicsdru_nidirect_theme_preprocess_page_title(&$variables) {
   $request = \Drupal::request();
 
   switch ($route->getRouteName()) {
-
-    // Preprocess node titles.
-    case "entity.node.canonical":
-      $node = $route->getParameter('node');
-      // Landing pages have a boolean field to enable title visibility.
-      if ($node->getType() === 'landing_page') {
-        // Is the title visible?
-        if (isset($node->field_enable_title) && isset($node->field_enable_title->get(0)->value)) {
-          $field_enable_title = $node->field_enable_title->get(0)->value;
-          if ($field_enable_title === '0') {
-            $variables['title_visible'] = FALSE;
-          }
-        }
-      }
-      break;
 
     // Preprocess news listing page title.
     case "nidirect_news.news_listing":

--- a/templates/content/node--landing-page--full.html.twig
+++ b/templates/content/node--landing-page--full.html.twig
@@ -1,0 +1,94 @@
+{#
+/**
+ * @file
+ * Theme override to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: Themed creation date field.
+ * - author_name: Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ *
+ * @todo Remove the id attribute (or make it a class), because if that gets
+ *   rendered twice on a page this is invalid CSS for example: two lists
+ *   in different view modes.
+ */
+#}
+{#
+Landing pages have a boolean field to enable title visibility.
+#}
+{% if node.field_enable_title %}
+  {%- set title_visible = node.field_enable_title.0.value == 1 ? true : false -%}
+{% endif %}
+<article{{ attributes.setAttribute('id', 'main-article').removeAttribute('role') }}>
+  {{- title_prefix -}}
+  {% if title_visible %}
+    <h1{{ title_attributes.addClass('page-title') }}>{{- label -}}</h1>
+  {% else %}
+    <h1{{ title_attributes.addClass(['page-title', 'visually-hidden']) }}>{{- label -}}</h1>
+  {% endif %}
+  {{- title_suffix -}}
+  {% if  content_attributes is not empty %}
+  <div{{ content_attributes }}>
+  {% endif %}
+  {{- content -}}
+  {% if  content_attributes is not empty %}
+  </div>
+  {% endif %}
+</article>


### PR DESCRIPTION
This PR:
- removes the title visibility logic from hook_preprocess_page_title
- does it in twig instead
- avoids use of twig tweak method to output the title {{ drupal_block('page_title_block' }} which appears to cause issues for search api (see https://github.com/dof-dss/nicsdru_nidirect_theme/pull/163).
