### PR TITLE
Output social sharing block in content region

### DIFF
--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -72,9 +72,15 @@
   {% if content_wrapper_attr is not empty %}
     <div{{ content_wrapper_attr }}>
       {{- page.content -}}
+      {%- if not is_front -%}
+        {{ drupal_block('origins_social_sharing', wrapper=false) }}
+      {%- endif -%}
     </div>
   {% else %}
     {{- page.content -}}
+    {%- if not is_front -%}
+      {{ drupal_block('origins_social_sharing', wrapper=false) }}
+    {%- endif -%}
   {% endif %}
   {%- if page.sidebar_second|stripped_length -%}
     <aside{{ sidebar_second_attr }}>


### PR DESCRIPTION
Using drupal_block in twig to output the social sharing block immediately below the main body content of the page to give a better DOM position and make more accessible to keyboard users (as previously they would have had to tab through all the right hand sidebar links to get to the social icons).

See related PR https://github.com/dof-dss/nidirect-drupal/pull/575