### PR TITLE
Set site search input label to same text as placeholder - "Search nid…

### DIFF
--- a/inc/alter.inc
+++ b/inc/alter.inc
@@ -81,3 +81,12 @@ function nicsdru_nidirect_theme_form_node_landing_page_layout_builder_form_alter
   // Hide revision information section.
   $form['revision_information']['#access'] = FALSE;
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function nicsdru_nidirect_theme_form_views_exposed_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  if (!empty($form['#id']) && $form['#id'] == 'views-exposed-form-search-site-search') {
+    $form['#info']['filter-search_api_fulltext']['label'] = t('Search nidirect');
+  }
+}


### PR DESCRIPTION
…irect"

Note there is hook in the origins theme that sets the search label to "Search this site".  The code should respect the view setting for the label if it exists - but that doesn't seem to work.  The view setting is "Search nidirect", but the Origins hook then overrides that to make it "Search this site"
```
/**
 * Implements hook_preprocess_views_view().
 */
function nicsdru_origins_theme_preprocess_views_view(&$variables) {
  $variables['attributes']['role'] = 'presentation';

  if ($variables['id'] === 'search') {
    $variables['exposed']['#attributes']['class'][] = Html::cleanCssIdentifier('search-form');
    $variables['exposed']['#attributes']['class'][] = Html::cleanCssIdentifier('search-form--site');
    // If a label for the search input is not defined in the view, set
    // default label text.
    $search_label =& $variables['exposed']['#info']['filter-search_api_fulltext']['label'];
    if (isset($search_label) && empty($search_label)) {
      $search_label = t("Search this site");
    }
    // The label should be visually hidden.
    $variables['exposed']['query']['#title_display'] = 'invisible';
  }
}
```

This PR creates a form alter hook in the nidirect theme that sets the label to "Search nidirect".  But perhaps it would be better to understand why the origins hook is not working?