### PR TITLE
Use empty() to detect presense/absence of values needed later on

### DIFF
--- a/inc/preprocess.inc
+++ b/inc/preprocess.inc
@@ -357,7 +357,7 @@ function nicsdru_nidirect_theme_preprocess_node(array &$variables) {
         }
       }
 
-      if ($variables['elements']['#photo_image_style']) {
+      if (!empty($variables['elements']['#photo_image_style'])) {
         // Some features use a different image style, eg: top set
         // of featured content on the homepage.
         $variables['content']['field_photo'][0]['#view_mode'] = $variables['elements']['#photo_image_style'];


### PR DESCRIPTION
Bit of an edge case but this does trigger if you don't have the image locally (sometimes during development). This also brings the empty check in line with the rest in the function that contains it.