### PR TITLE
Fix double html encoding of symptoms in health condition search results

### DIFF
--- a/templates/content/node--health-condition--search-result.html.twig
+++ b/templates/content/node--health-condition--search-result.html.twig
@@ -7,7 +7,7 @@
 {% set symptom_list %}
   {% for i in 1..4 %}
     {% set symptom = attribute(content, 'field_hc_primary_symptom_' ~ i) | render | striptags %}
-    {% if symptom is not empty %}<li class="meta">{{ symptom }}</li>{% endif %}
+    {% if symptom is not empty %}<li class="meta">{{ symptom|raw }}</li>{% endif %}
   {% endfor %}
 {% endset %}
 {% if symptom_list|trim is not empty %}


### PR DESCRIPTION
Symptom is already html encoded, so output using raw filter.